### PR TITLE
Add python3-ev3dev2 package to default install list

### DIFF
--- a/ev3dev-stretch/layers/generic/brickstrap/generic/run
+++ b/ev3dev-stretch/layers/generic/brickstrap/generic/run
@@ -30,6 +30,7 @@ apt-get install --yes --no-install-recommends \
     python3 \
     python3-bluez \
     python3-ev3dev \
+    python3-ev3dev2 \
     python3-evdev \
     python3-gattlib \
     python3-gi \


### PR DESCRIPTION
I did this in-browser and haven't tested it, but isn't that half the fun?