### PR TITLE
Preinstall OpenJDK 11 JRI in the EV3 image

### DIFF
--- a/ev3dev-stretch/layers/generic/brickstrap/generic/run
+++ b/ev3dev-stretch/layers/generic/brickstrap/generic/run
@@ -55,6 +55,11 @@ if [[ "$(dpkg --print-architecture)" != "armel" ]]; then
         nodejs-legacy
 fi
 
+if dpkg -s linux-image-ev3dev-ev3 >/dev/null 2>&1; then
+    apt-get install --yes --no-install-recommends \
+        jri-11-ev3
+fi
+
 # prevent openrobertalab from running
 systemctl mask openrobertalab.service
 


### PR DESCRIPTION
Hi,

I and @jabrena would like to include Java in the main SD card image (this follows [ev3dev/#1099](https://github.com/ev3dev/ev3dev/issues/1099)).

This PR adds the last piece of the puzzle:
* Small Java distribution is built on AdoptOpenJDK CI (`jri-ev3.tar.gz`).
* The resulting tarball is repackaged to a Debian package (`jri-11-ev3_11.0.1~13-1_armel.deb`).
* Debian package is then uploaded to ev3dev repository (`jri-11-ev3`).
* Finally, the package is installed from ev3dev repository to the base image.

The Java package itself without dependencies has around 66 MB when unpacked. If a smaller size is needed, we can enable compression of included classes - that shrinks it to either 50 MB or 39 MB, depending on the type of the compression.
The package has the following dependencies:
```
ca-certificates-java, java-common, libcups2, liblcms2-2, libjpeg62-turbo, libfontconfig1, util-linux, libasound2, libc6, libfreetype6, zlib1g
```

The library dependencies come from original openjdk package in Debian. Most of them should be already installed in the system.

Thanks,

Jakub